### PR TITLE
If it's stupid, but it works: it's not stupid.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -1035,7 +1035,7 @@ endif;
                                                     
                                                     <?php
                                                     
-                                                        $getFailLog = file_get_contents(FAIL_LOG); 
+                                                        $getFailLog = str_replace("\r\ndate", "date", file_get_contents(FAIL_LOG));
                                                         $gotFailLog = json_decode($getFailLog, true);
 
                                                         function getColor($colorTest){

--- a/user.php
+++ b/user.php
@@ -593,7 +593,7 @@ EOT;
                 
                 if(file_exists(FAIL_LOG)) { 
                     
-                    $getFailLog = file_get_contents(FAIL_LOG); 
+                    $getFailLog = str_replace("\r\ndate", "date", file_get_contents(FAIL_LOG));
                     
                     $gotFailLog = json_decode($getFailLog, true);
                 

--- a/user.php
+++ b/user.php
@@ -607,11 +607,11 @@ EOT;
 
                     array_push($gotFailLog["auth"], $failLogEntry);
                     
-                    $writeFailLog = json_encode($gotFailLog);
+                    $writeFailLog = str_replace("date", "\r\ndate", json_encode($gotFailLog));
 
                 }else{
 
-                    $writeFailLog = json_encode($failLogEntryFirst);
+                    $writeFailLog = str_replace("date", "\r\ndate", json_encode($failLogEntryFirst));
 
                 }
                 


### PR DESCRIPTION
I tried my best and feel terrible for this hack. But it works. The json is readable by organizr and fail2ban.

Further info:

special newline chars are added to the json file (\r\n).

upon reading the file those characters are removed from the data stream.

A proper way to do this would be a simple log file, readable by fail2ban with
Timestamp - ip - username - bad_auth