### PR TITLE
fix NZBGet homepage widget from having horizontal scroll on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+﻿@charset "UTF-8";
 /*
  *
  *   ADVANTAGE - Responsive Admin Theme
@@ -5700,7 +5700,7 @@ label {
 
 .progress-widget tr td, .progress-widget tr th {
   vertical-align: middle !important;
-  padding: 8px 20px !important;
+  padding: 8px 20px;
 }
 
 .progress-widget tr td + td {

--- a/functions.php
+++ b/functions.php
@@ -1899,10 +1899,10 @@ function nzbgetConnect($list = 'listgroups') {
         }
         
         $gotNZB[] = '<tr>
-                        <td>'.$downloadName.'</td>
-                        <td>'.$downloadStatus.'</td>
-                        <td>'.$downloadCategory.'</td>
-                        <td>
+                        <td class="col-xs-7 nzbtable-file-row">'.$downloadName.'</td>
+                        <td class="col-xs-2 nzbtable nzbtable-row">'.$downloadStatus.'</td>
+                        <td class="col-xs-1 nzbtable nzbtable-row">'.$downloadCategory.'</td>
+                        <td class="col-xs-2 nzbtable nzbtable-row">
                             <div class="progress">
                                 <div class="progress-bar progress-bar-'.$downloadHealth.' '.$progressBar.'" role="progressbar" aria-valuenow="'.$downloadPercent.'" aria-valuemin="0" aria-valuemax="100" style="width: '.$downloadPercent.'%">
                                     <p class="text-center">'.round($downloadPercent).'%</p>

--- a/homepage.php
+++ b/homepage.php
@@ -189,7 +189,30 @@ $endDate = date('Y-m-d',strtotime("+".CALENDARENDDAY." days"));
                 text-align: left;
                 padding-bottom: 2px !important;
                 overflow: hidden !important;
-            }<?php if(CUSTOMCSS == "true") : 
+            } @media screen and (max-width: 576px) {
+				.nzbtable {
+					padding-left: 5px !important;
+					padding-right: 2px !important;
+					font-size: 10px !important;
+					word-break: break-word !important;
+				}
+				.nzbtable-file-row {
+					padding-left: 5px !important;
+					padding-right: 2px !important;
+					font-size: 10px !important;
+					white-space: normal !important;
+					word-break: break-all !important;
+					width: 0% !important;
+				}
+            } .nzbtable-file-row {
+				white-space: normal !important;
+				word-break: break-all !important;
+				width: 0% !important;
+			}.nzbtable-row {
+				white-space: normal !important;
+				width: 0% !important;
+				font-size: 12px; !important;
+			}<?php if(CUSTOMCSS == "true") : 
 $template_file = "custom.css";
 $file_handle = fopen($template_file, "rb");
 echo fread($file_handle, filesize($template_file));
@@ -241,10 +264,10 @@ endif; ?>
                                                 <table class="table table-striped progress-widget zero-m" style="max-height: 300px">
                                                     <thead>
                                                         <tr>
-                                                            <th><?php echo $language->translate("FILE");?></th>
-                                                            <th><?php echo $language->translate("STATUS");?></th>
-                                                            <th><?php echo $language->translate("CATEGORY");?></th>
-                                                            <th><?php echo $language->translate("PROGRESS");?></th>
+                                                            <th class="col-xs-7 nzbtable-file-row"><?php echo $language->translate("FILE");?></th>
+                                                            <th class="col-xs-2 nzbtable"><?php echo $language->translate("STATUS");?></th>
+                                                            <th class="col-xs-1 nzbtable"><?php echo $language->translate("CATEGORY");?></th>
+                                                            <th class="col-xs-2 nzbtable"><?php echo $language->translate("PROGRESS");?></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody class="dl-queue sabnzbd"></tbody>
@@ -257,10 +280,10 @@ endif; ?>
                                                 <table class="table table-striped progress-widget zero-m" style="max-height: 300px">
                                                     <thead>
                                                         <tr>
-                                                            <th><?php echo $language->translate("FILE");?></th>
-                                                            <th><?php echo $language->translate("STATUS");?></th>
-                                                            <th><?php echo $language->translate("CATEGORY");?></th>
-                                                            <th><?php echo $language->translate("PROGRESS");?></th>
+                                                            <th class="col-xs-7 nzbtable-file-row"><?php echo $language->translate("FILE");?></th>
+                                                            <th class="col-xs-2 nzbtable"><?php echo $language->translate("STATUS");?></th>
+                                                            <th class="col-xs-1 nzbtable"><?php echo $language->translate("CATEGORY");?></th>
+                                                            <th class="col-xs-2 nzbtable"><?php echo $language->translate("PROGRESS");?></th>
                                                         </tr>
                                                     </thead>
                                                     <tbody class="dl-history sabnzbd"></tbody>

--- a/homepage.php
+++ b/homepage.php
@@ -227,6 +227,12 @@ endif; ?>
             <div id="content" class="container-fluid">
 <!-- <button id="numBnt">Numerical</button> -->
                 <br/>
+
+				 <?php if (qualifyUser(HOMEPAGECUSTOMHTML1AUTH) && HOMEPAGECUSTOMHTML1) { ?>
+				<div>
+					<?php echo HOMEPAGECUSTOMHTML1; ?>
+				</div>
+                <?php } ?>
                 <?php if((NZBGETURL != "" && qualifyUser(NZBGETHOMEAUTH)) || (SABNZBDURL != "" && qualifyUser(SABNZBDHOMEAUTH))) { ?>
                 <div id="downloadClientRow" class="row">
                     <sort>2</sort>
@@ -351,12 +357,6 @@ endif; ?>
                         <div id="calendar" class="fc-calendar box-shadow fc fc-ltr fc-unthemed"></div>
                     </div>
                 </div>
-                <?php } ?>
-				
-                <?php if (qualifyUser(HOMEPAGECUSTOMHTML1AUTH) && HOMEPAGECUSTOMHTML1) { ?>
-				<div>
-					<?php echo HOMEPAGECUSTOMHTML1; ?>
-				</div>
                 <?php } ?>
             </div>    
         </div>


### PR DESCRIPTION
I primarily access Organizr from mobile and would have trouble with the screen resizing and becoming unresponsive (to touch) after the function call to NZBGet would return the table of downloads/history. I did some research and made a few slight changes to the CSS.

I don't have SABnzbd, so I don't know if this is a problem for that as well.

I also found that the custom HTML was more beneficial at the top of the homepage (for status messages and such). It's really more of a preference thing. I'm not sure if you want to move this or wait until version 2.0 for a homepage that can be reorganized entirely.

This is my first pull request ever...still relatively new to git. Hoping I did everything correctly!
