### PR TITLE
Add missing slash to error.php URLs

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 // ===================================
 // Define Version
@@ -1644,11 +1644,11 @@ function qualifyUser($type, $errOnFail = false) {
 	
 	if (!$authorized && $errOnFail) {
 		if ($GLOBALS['USER']->authenticated) {
-			header('Location: '.dirname($_SERVER['SCRIPT_NAME']).'error.php?error=401');
-			echo '<script>window.location.href = \''.dirname($_SERVER['SCRIPT_NAME']).'error.php?error=401\'</script>';
+			header('Location: '.dirname($_SERVER['SCRIPT_NAME']).'/error.php?error=401');
+			echo '<script>window.location.href = \''.dirname($_SERVER['SCRIPT_NAME']).'/error.php?error=401\'</script>';
 		} else {
-			header('Location: '.dirname($_SERVER['SCRIPT_NAME']).'error.php?error=999');
-			echo '<script>window.location.href = \''.dirname($_SERVER['SCRIPT_NAME']).'error.php?error=999\'</script>';
+			header('Location: '.dirname($_SERVER['SCRIPT_NAME']).'/error.php?error=999');
+			echo '<script>window.location.href = \''.dirname($_SERVER['SCRIPT_NAME']).'/error.php?error=999\'</script>';
 		}
 
 		debug_out('Not Authorized' ,1);


### PR DESCRIPTION
I found that when accessing Organizr and having authentication required on the homepage I am given a 404 error from my web server (nginx) but the expected behaviour is to be prompted to login. After reviewing the developer console I fould my browser being redirected to /organizrerror.php?error=999 instead of /organizr/error.php?error=999 so this PR resolves that issue.