### PR TITLE
Restore RFC mail timeout

### DIFF
--- a/vendor/phpmailer/phpmailer/class.phpmailer.php
+++ b/vendor/phpmailer/phpmailer/class.phpmailer.php
@@ -312,7 +312,7 @@ class PHPMailer
      * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
      * @var integer
      */
-    public $Timeout = 10;
+    public $Timeout = 300;
 
     /**
      * SMTP class debug output mode.


### PR DESCRIPTION
For some reason the vendor library was edited and a lower smtp timeout of 10 seconds was set. This does not follow RFC2821 and can cause problems with latent smtp servers.

e.g. this does cause mail to fail to send over long distance connections, such as my Organizr instance in Germany and my mail server in Australia.