### PR TITLE
Added Emby home video item

### DIFF
--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -121,6 +121,20 @@ function resolveEmbyItem($itemDetails) {
             $embyItem['nowPlayingTitle'] = @$item['Name'];
             $embyItem['nowPlayingBottom'] = @$item['ProductionYear'];
             break;
+        case 'Video':
+            $embyItem['type'] = 'movie';
+            $embyItem['title'] = $item['Name'];
+            $embyItem['summary'] = '';
+            $embyItem['ratingKey'] = $item['Id'];
+            $embyItem['thumb'] = $item['Id'];
+            $embyItem['key'] = $item['Id'] . "-list";
+            $embyItem['nowPlayingThumb'] = $item['Id'];
+            $embyItem['nowPlayingKey'] = $item['Id'] . "-np";
+            $embyItem['metadataKey'] = $item['Id'];
+            $embyItem['nowPlayingImageType'] = isset($item['ImageTags']['Primary']) ? "Primary" : (isset($item['BackdropImageTags']) ? "Backdrop" : false);
+            $embyItem['nowPlayingTitle'] = @$item['Name'];
+            $embyItem['nowPlayingBottom'] = @$item['ProductionYear'];
+            break;
         default:
             return false;
 	}
@@ -474,7 +488,7 @@ function embyConnect($action,$key=null,$skip=false){
 				return $api;
 			}
 		}catch( Requests_Exception $e ) {
-			writeLog('error', 'Plex Connect Function - Error: '.$e->getMessage(), 'SYSTEM');
+			writeLog('error', 'Emby Connect Function - Error: '.$e->getMessage(), 'SYSTEM');
 		};
 	}
 	return false;


### PR DESCRIPTION
This is all about home videos:
a concept for home video items, I don't really have any metadata for the info card, like a summary or something, so that's empty.
Stream info seems to work, it succesfully displays the title and the primary image for the nowplaying item.
For the recent item it should display the thumbnail, since it now displays the primary image.
However, this might be only my configuration, but Emby automatically generates an image as a primary image and I have a custom thumbnail that I'm using.
Also I used 'movie' for the $embyItem['type'], maybe you want to add a new type called video or something like that.

Besides all this about home videos, I changed Plex to Emby in an error message.

Please let me know if I can do anything to help any further.