### PR TITLE
Fix emby links

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -648,7 +648,7 @@ function resolveEmbyItem($address, $token, $item, $nowPlaying = false, $showName
 	}else{
 		$URL = EMBYURL."/web/itemdetails.html?id=".$itemDetails['Id'];
 	}*/
-	$URL = EMBYURL."/web/itemdetails.html?id=".$itemDetails['Id'];
+	$URL = EMBYURL."/web/#!/itemdetails.html?id=".$itemDetails['Id'];
 	switch ($itemDetails['Type']) {
 		case 'Episode':
 		case 'Series':


### PR DESCRIPTION
Emby changed the way links are starting with the Emby version v3.4.1.16
See: https://github.com/tidusjar/Ombi/issues/2368

This is what links currently look like on Emby version 3.5.2.0
![screen shot 2018-08-17 at 17 42 56-fullpage](https://user-images.githubusercontent.com/10184095/44293939-185d2200-a245-11e8-94b1-f70c069ec6e0.png)
