### PR TITLE
Ombi SSO error

### DIFF
--- a/api/functions/sso-functions.php
+++ b/api/functions/sso-functions.php
@@ -39,6 +39,7 @@ function getOmbiToken($username, $password, $oAuthToken = null)
 		);
 		$endpoint = ($oAuthToken) ? '/api/v1/Token/plextoken' : '/api/v1/Token';
 		$options = (localURL($url)) ? array('verify' => false) : array();
+		$url = rtrim($url, '/');
 		$response = Requests::post($url . $endpoint, $headers, json_encode($data), $options);
 		if ($response->success) {
 			$token = json_decode($response->body, true)['access_token'];
@@ -72,6 +73,7 @@ function getTautulliToken($username, $password, $plexToken = null)
 					"remember_me" => 1,
 				);
 				$options = (localURL($url)) ? array('verify' => false) : array();
+				$url = rtrim($url, '/');
 				$response = Requests::post($url . '/auth/signin', $headers, $data, $options);
 				if ($response->success) {
 					$token[$key]['token'] = json_decode($response->body, true)['token'];


### PR DESCRIPTION
Ombi SSO returns 404 if url ends with a slash, because another slash gets added when we append the endpoint url. This should fix this case, and leave untouched when there isn't a final slash.