### PR TITLE
Oauth login fix

### DIFF
--- a/api/functions/sso-functions.php
+++ b/api/functions/sso-functions.php
@@ -32,8 +32,8 @@ function getOmbiToken($username, $password, $oAuthToken = null)
 			"Content-Type" => "application/json"
 		);
 		$data = array(
-			"username" => $username,
-			"password" => $password,
+			"username" => ($oAuthToken ? "" : $username),
+			"password" => ($oAuthToken ? "" : $password),
 			"rememberMe" => "true",
 			"plexToken" => $oAuthToken
 		);
@@ -66,8 +66,8 @@ function getTautulliToken($username, $password, $plexToken = null)
 					"User-Agent" => isset($_SERVER ['HTTP_USER_AGENT']) ? $_SERVER ['HTTP_USER_AGENT'] : null
 				);
 				$data = array(
-					"username" => $username,
-					"password" => $password,
+			                "username" => ($plexToken ? "" : $username),
+			                "password" => ($plexToken ? "" : $password),
 					"token" => $plexToken,
 					"remember_me" => 1,
 				);


### PR DESCRIPTION
This fixes the issue with username/password fields being populated while logging in with oAuth. I've tested this locally and SSO works even with the fields filled. This could conceivably be done by just not setting username/password in these arrays in the first place, but I'm unsure if those were set for reason.