### PR TITLE
Emby User Templates

### DIFF
--- a/api/plugins/config/invites.php
+++ b/api/plugins/config/invites.php
@@ -3,5 +3,5 @@ return array(
 	'INVITES-enabled' => false,
 	'INVITES-type-include' => 'plex',
 	'INVITES-plexLibraries' => '',
-	'INVITES-EmbyDefaultUserConfig' => ''
+	'INVITES-EmbyTemplate' => ''
 );

--- a/api/plugins/invites.php
+++ b/api/plugins/invites.php
@@ -242,10 +242,10 @@ function invitesGetSettings()
 			),
 			array(
 				'type' => 'text',
-				'name' => 'INVITES-EmbyDefaultUserConfig',
-				'label' => 'Emby Default User Config JSON',
-				'value' => $GLOBALS['INVITES-EmbyDefaultUserConfig'],
-				'placeholder' => '{...}'
+				'name' => 'INVITES-EmbyTemplate',
+				'label' => 'Emby User to be used as template for new users',
+				'value' => $GLOBALS['INVITES-EmbyTemplate'],
+				'placeholder' => 'AdamSmith'
 			)
 		),
 		'FYI' => array(


### PR DESCRIPTION
Users are not required to manually specify the settings they want to be updated on user creation and libraries shared. Instead, emby now copies settings from the specified user. This addresses the primary problem with the first emby invite structure  #1127 and further work on #1124 .

Whether or not to use this method of user creation I feel is a stylistic choice about how @causefx wants users to interact with Organizer, because frankly the current strategy and this one both have drawbacks. For example, SysAdmins will likely want their template user hidden even if their actual users are not hidden, and that combination is not possible without another toggle and more JSON manipulation that to some extent defeats the purpose of this simple solution. 