### PR TITLE
JDownloader Actions / Improved Status Labeling / Removed History Tab

### DIFF
--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -739,7 +739,7 @@ function jdownloaderConnect()
 {
     if ($GLOBALS['homepageJdownloaderEnabled'] && !empty($GLOBALS['jdownloaderURL']) && qualifyRequest($GLOBALS['homepageJdownloaderAuth'])) {
         $url = qualifyURL($GLOBALS['jdownloaderURL']);
-        $url = $url . '/';
+
         try {
             $options = (localURL($url)) ? array('verify' => false) : array();
             $response = Requests::get($url, array(), $options);

--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -748,15 +748,23 @@ function jdownloaderConnect()
                 $packages = $temp['packages'];
                 if ($packages['downloader']) {
                     $api['content']['queueItems'] = $packages['downloader'];
+                }else{
+                    $api['content']['queueItems'] = [];
                 }
                 if ($packages['linkgrabber_decrypted']) {
                     $api['content']['grabberItems'] = $packages['linkgrabber_decrypted'];
+                }else{
+                    $api['content']['grabberItems'] = [];
                 }
                 if ($packages['linkgrabber_failed']) {
                     $api['content']['encryptedItems'] = $packages['linkgrabber_failed'];
+                }else{
+                    $api['content']['encryptedItems'] = [];
                 }
                 if ($packages['linkgrabber_offline']) {
                     $api['content']['offlineItems'] = $packages['linkgrabber_offline'];
+                }else{
+                    $api['content']['offlineItems'] = [];
                 }
 
                 $api['content']['$status'] = array($temp['downloader_state'], $temp['grabber_collecting'], $temp['update_ready']);

--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -748,23 +748,18 @@ function jdownloaderConnect()
                 $packages = $temp['packages'];
                 if ($packages['downloader']) {
                     $api['content']['queueItems'] = $packages['downloader'];
-                } else {
-                    $api['content']['queueItems'] = [];
                 }
-                $grabbed = array();
                 if ($packages['linkgrabber_decrypted']) {
-                    $grabbed = array_merge($grabbed, $packages['linkgrabber_decrypted']);
+                    $api['content']['grabberItems'] = $packages['linkgrabber_decrypted'];
                 }
                 if ($packages['linkgrabber_failed']) {
-                    $grabbed = array_merge($grabbed, $packages['linkgrabber_failed']);
+                    $api['content']['encryptedItems'] = $packages['linkgrabber_failed'];
                 }
                 if ($packages['linkgrabber_offline']) {
-                    $grabbed = array_merge($grabbed, $packages['linkgrabber_offline']);
+                    $api['content']['offlineItems'] = $packages['linkgrabber_offline'];
                 }
-                $api['content']['grabberItems'] = $grabbed;
 
-                $status = array($temp['downloader_state'], $temp['grabber_collecting'], $temp['update_ready']);
-                $api['content']['$status'] = $status;
+                $api['content']['$status'] = array($temp['downloader_state'], $temp['grabber_collecting'], $temp['update_ready']);
             }
         } catch (Requests_Exception $e) {
             writeLog('error', 'JDownloader Connect Function - Error: ' . $e->getMessage(), 'SYSTEM');

--- a/api/functions/homepage-functions.php
+++ b/api/functions/homepage-functions.php
@@ -1017,6 +1017,7 @@ function getHomepageList()
                                 <div class="panel-body">
 									<ul class="list-icons">
                                         <li><i class="fa fa-chevron-right text-danger"></i> <a href="https://pypi.org/project/myjd-api/" target="_blank">Download [myjd-api] Module</a></li>
+                                        <li><i class="fa fa-chevron-right text-danger"></i> Add <b>/api/myjd</b> to the URL if you are using <a href="https://pypi.org/project/RSScrawler/" target="_blank">RSScrawler</a></li>
                                     </ul>
                                 </div>
                             </div>

--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1940,12 +1940,80 @@ function downloader($array)
 					break;
 			}
 			break;
+        case 'jdownloader':
+            switch ($array['data']['action']) {
+                case 'resume':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                case 'pause':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                case 'stop':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                case 'update':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                case 'retry':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                case 'remove':
+                    jdownloaderAction($array['data']['action'], $array['data']['target']);
+                    break;
+                default:
+                    # code...
+                    break;
+            }
+            break;
 		case 'nzbget':
 			break;
 		default:
 			# code...
 			break;
 	}
+}
+
+function jdownloaderAction($action = null, $target = null)
+{
+    if ($GLOBALS['homepageJdownloaderEnabled'] && !empty($GLOBALS['jdownloaderURL']) && !empty($GLOBALS['jdownloaderToken']) && qualifyRequest($GLOBALS['homepageJdownloaderAuth'])) {
+        $url = qualifyURL($GLOBALS['jdownloaderURL']);
+        switch ($action) {
+            case 'resume':
+                # TODO: fix this for unique packages (start online, delete offline ones)
+                $id = ($target !== '' && $target !== 'main' && isset($target)) ? 'mode=queue&name=pause&value=' . $target . '&' : 'mode=pause';
+                $url = $url . '/api?' . $id . '&output=json&apikey=' . $GLOBALS['jdownloaderToken'];
+                break;
+            case 'pause':
+                # code...
+                break;
+            case 'stop':
+                # code...
+                break;
+            case 'update':
+                # code...
+                break;
+            case 'retry':
+                # code...
+                break;
+            case 'remove':
+                # code...
+                break;
+            default:
+                # code...
+                break;
+        }
+        try {
+            $options = (localURL($url)) ? array('verify' => false) : array();
+            $response = Requests::get($url, array(), $options);
+            if ($response->success) {
+                $api['content'] = json_decode($response->body, true);
+            }
+        } catch (Requests_Exception $e) {
+            writeLog('error', 'JDownloader Connect Function - Error: ' . $e->getMessage(), 'SYSTEM');
+        };
+        $api['content'] = isset($api['content']) ? $api['content'] : false;
+        return $api;
+    }
 }
 
 function sabnzbdAction($action = null, $target = null)

--- a/js/functions.js
+++ b/js/functions.js
@@ -4910,20 +4910,23 @@ function buildDownloaderItem(array, source, type='none'){
                 break;
             }
 
-            /*
-            if(array.content.$status[0] != 'RUNNING'){
-                var state = `<a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-play"></i></span></a>`;
-                var active = 'grayscale';
-            }else{
-                var state = `<a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="pause" data-target="main"><i class="fa fa-pause"></i></span></a>`;
-                var active = '';
-            }
-            $('.jdownloader-downloader-action').html(state);
-            */
-
-            if(array.content.queueItems.length == 0 && array.content.encryptedItems.length == 0 && array.content.offlineItems.length == 0){
+            if(array.content.queueItems.length == 0 && array.content.grabberItems.length == 0 && array.content.encryptedItems.length == 0 && array.content.offlineItems.length == 0){
                 queue = '<tr><td class="max-texts" lang="en">Nothing in queue</td></tr>';
+            }else{
+                if(array.content.$status[0] == 'RUNNING') {
+                    var queue = `
+                        <tr><td>
+                            <a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="pause" data-target="main"><i class="fa fa-pause"></i></span></a>
+                            <a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="stop" data-target="main"><i class="fa fa-stop"></i></span></a>
+                        </td></tr>
+                        `;
+                }else if(array.content.$status[0] == 'PAUSE'){
+                    var queue = `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-fast-forward"></i></span></a></td></tr>`;
+                }else{
+                    var queue = `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-play"></i></span></a></td></tr>`;
+                }
             }
+
             $.each(array.content.queueItems, function(i,v) {
                 count = count + 1;
                 if(v.speed == null){
@@ -4943,7 +4946,7 @@ function buildDownloaderItem(array, source, type='none'){
                 queue += `
                 <tr>
                     <td class="max-texts">`+v.name+`</td>
-                    <td class="hidden-xs">`+v.speed+`</td>
+                    <td>`+v.speed+`</td>
                     <td class="hidden-xs" alt="`+v.done+`">`+v.size+`</td>
                     <td class="hidden-xs">`+v.eta+`</td>
                     <td class="text-right">
@@ -4959,7 +4962,7 @@ function buildDownloaderItem(array, source, type='none'){
                 queue += `
                 <tr>
                     <td class="max-texts">`+v.name+`</td>
-                    <td class="hidden-xs"> Online </td>
+                    <td>Online</td>
                     <td class="hidden-xs"> -- </td>
                     <td class="hidden-xs"> -- </td>
                     <td class="text-right">
@@ -4975,7 +4978,7 @@ function buildDownloaderItem(array, source, type='none'){
                 queue += `
                 <tr>
                     <td class="max-texts">`+v.name+`</td>
-                    <td class="hidden-xs"> Encrypted </td>
+                    <td>Encrypted</td>
                     <td class="hidden-xs"> -- </td>
                     <td class="hidden-xs"> -- </td>
                     <td class="text-right">
@@ -4991,7 +4994,7 @@ function buildDownloaderItem(array, source, type='none'){
                 queue += `
                 <tr>
                     <td class="max-texts">`+v.name+`</td>
-                    <td class="hidden-xs"> Offline </td>
+                    <td>Offline</td>
                     <td class="hidden-xs"> -- </td>
                     <td class="hidden-xs"> -- </td>
                     <td class="text-right">
@@ -5317,6 +5320,10 @@ function buildDownloader(source){
     var historyButton = 'HISTORY';
     switch (source) {
         case 'jdownloader':
+            var queue = true;
+            var history = false;
+            queueButton = 'REFRESH';
+            break;
         case 'sabnzbd':
         case 'nzbget':
             var queue = true;
@@ -5413,6 +5420,10 @@ function buildDownloaderCombined(source){
     var historyButton = 'HISTORY';
     switch (source) {
         case 'jdownloader':
+            var queue = true;
+            var history = false;
+            queueButton = 'REFRESH';
+            break;
         case 'sabnzbd':
         case 'nzbget':
             var queue = true;

--- a/js/functions.js
+++ b/js/functions.js
@@ -4923,7 +4923,7 @@ function buildDownloaderItem(array, source, type='none'){
                 }else if(array.content.$status[0] == 'PAUSE'){
                     queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-fast-forward"></i></span></a></td></tr>`;
                 }else{
-                    queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-play"></i></span></a></td></tr>`;
+                    queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="start" data-target="main"><i class="fa fa-play"></i></span></a></td></tr>`;
                 }
                 if(array.content.$status[1]) {
                     queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="update" data-target="main"><i class="fa fa-globe"></i></span></a></td></tr>`;

--- a/js/functions.js
+++ b/js/functions.js
@@ -1894,7 +1894,7 @@ function checkTabHomepageItem(id, name, url, urlLocal){
         addEditHomepageItem(id,'Plex');
     }else if(name.includes('emby') || url.includes('emby') || urlLocal.includes('emby')){
         addEditHomepageItem(id,'Emby');
-    }else if(name.includes('jdownloader') || url.includes('jdownloader') || urlLocal.includes('jdownloader')){
+    }else if(name.includes('jdownloader') || url.includes('jdownloader') || urlLocal.includes('jdownloader') || name.includes('rsscrawler') || url.includes('rsscrawler') || urlLocal.includes('rsscrawler')){
         addEditHomepageItem(id,'jDownloader');
     }else if(name.includes('sab') || url.includes('sab') || urlLocal.includes('sab')){
         addEditHomepageItem(id,'SabNZBD');
@@ -4902,7 +4902,6 @@ function requestList (list, type, page=1) {
 function buildDownloaderItem(array, source, type='none'){
     //console.log(array);
     var queue = '';
-    var history = '';
     var count = 0;
 	switch (source) {
         case 'jdownloader':
@@ -4922,24 +4921,24 @@ function buildDownloaderItem(array, source, type='none'){
             $('.jdownloader-downloader-action').html(state);
             */
 
-            if(array.content.queueItems.length == 0){
+            if(array.content.queueItems.length == 0 && array.content.encryptedItems.length == 0 && array.content.offlineItems.length == 0){
                 queue = '<tr><td class="max-texts" lang="en">Nothing in queue</td></tr>';
             }
             $.each(array.content.queueItems, function(i,v) {
                 count = count + 1;
                 if(v.speed == null){
-                    if(v.percentage == '100'){
-                        v.speed = '--';
-                    }else{
-                        v.speed = 'Stopped';
-                    }
+                    v.speed = 'Stopped';
                 }
                 if(v.eta == null){
                     if(v.percentage == '100'){
-                        v.eta = 'Complete';
+                        v.speed = 'Complete';
+                        v.eta = '--';
                     }else{
                         v.eta = '--';
                     }
+                }
+                if(v.enabled == null){
+                    v.speed = 'Disabled';
                 }
                 queue += `
                 <tr>
@@ -4955,13 +4954,51 @@ function buildDownloaderItem(array, source, type='none'){
                 </tr>
                 `;
             });
-            if(array.content.grabberItems.length == 0){
-                history = '<tr><td class="max-texts" lang="en">Nothing in Linkgrabbber</td></tr>';
-            }
             $.each(array.content.grabberItems, function(i,v) {
-                history += `
+                count = count + 1;
+                queue += `
                 <tr>
-                    <td class="max-texts">`+ v.name+`</td>
+                    <td class="max-texts">`+v.name+`</td>
+                    <td class="hidden-xs"> Online </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="text-right">
+                        <div class="progress progress-lg m-b-0">
+                            <div class="progress-bar progress-bar-info" style="width: 0%;" role="progressbar">0%</div>
+                        </div>
+                    </td>
+                </tr>
+                `;
+            });
+            $.each(array.content.encryptedItems, function(i,v) {
+                count = count + 1;
+                queue += `
+                <tr>
+                    <td class="max-texts">`+v.name+`</td>
+                    <td class="hidden-xs"> Encrypted </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="text-right">
+                        <div class="progress progress-lg m-b-0">
+                            <div class="progress-bar progress-bar-info" style="width: 0%;" role="progressbar">0%</div>
+                        </div>
+                    </td>
+                </tr>
+                `;
+            });
+            $.each(array.content.offlineItems, function(i,v) {
+                count = count + 1;
+                queue += `
+                <tr>
+                    <td class="max-texts">`+v.name+`</td>
+                    <td class="hidden-xs"> Offline </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="hidden-xs"> -- </td>
+                    <td class="text-right">
+                        <div class="progress progress-lg m-b-0">
+                            <div class="progress-bar progress-bar-info" style="width: 0%;" role="progressbar">0%</div>
+                        </div>
+                    </td>
                 </tr>
                 `;
             });

--- a/js/functions.js
+++ b/js/functions.js
@@ -4914,19 +4914,21 @@ function buildDownloaderItem(array, source, type='none'){
                 queue = '<tr><td class="max-texts" lang="en">Nothing in queue</td></tr>';
             }else{
                 if(array.content.$status[0] == 'RUNNING') {
-                    var queue = `
+                    queue += `
                         <tr><td>
                             <a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="pause" data-target="main"><i class="fa fa-pause"></i></span></a>
                             <a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="stop" data-target="main"><i class="fa fa-stop"></i></span></a>
                         </td></tr>
                         `;
                 }else if(array.content.$status[0] == 'PAUSE'){
-                    var queue = `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-fast-forward"></i></span></a></td></tr>`;
+                    queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-fast-forward"></i></span></a></td></tr>`;
                 }else{
-                    var queue = `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-play"></i></span></a></td></tr>`;
+                    queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="resume" data-target="main"><i class="fa fa-play"></i></span></a></td></tr>`;
+                }
+                if(array.content.$status[1]) {
+                    queue += `<tr><td><a href="#"><span class="downloader mouse" data-source="jdownloader" data-action="update" data-target="main"><i class="fa fa-globe"></i></span></a></td></tr>`;
                 }
             }
-
             $.each(array.content.queueItems, function(i,v) {
                 count = count + 1;
                 if(v.speed == null){


### PR DESCRIPTION
- JDownloader can now be started, stopped, paused, unpaused and updated from the homepage
- Added refresh action
- Using the history tab was semantically wrong. Instead, packages that are still in the Linkgrabber are now added to the bottom of the queue and marked accordingly.
- All possible statuses are detected and labeled coherently:
![status-types](https://user-images.githubusercontent.com/9930448/60576153-23497400-9d7d-11e9-8525-0f128b511aaa.PNG)
- Ensured compatibility with my main project, RSScrawler
