### PR TITLE
Nginx auth alias

### DIFF
--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1653,13 +1653,13 @@ function auth()
     {
         try {
             $connect = new Dibi\Connection([
-                                               'driver'   => 'sqlite3',
-                                               'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],
-                                           ]);
-            $all = $connect->fetch("SELECT group_id FROM tabs WHERE name = '%?%'", $tab);
-            return $all ? $all['group_id'] : 0;
+			    'driver' => 'sqlite3',
+			    'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],
+		    ]);
+            $row = $connect->fetch('SELECT group_id FROM tabs WHERE name = %~like~', $tab);
+            return $row ? $row['group_id'] : 0;
         } catch (\Dibi\Exception $e) {
-            writeLog('error', 'Tab Group Function - Error Fetching Tab Alias', $tab);
+            writeLog('error', 'Tab Group Function - Error Fetching Tab Group', $tab);
             return 0;
         }
 

--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1649,21 +1649,19 @@ function auth()
 	}
 }
 
-    function getTabGroup ($tab)
-    {
-        try {
-            $connect = new Dibi\Connection([
-			    'driver' => 'sqlite3',
-			    'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],
-		    ]);
-            $row = $connect->fetch('SELECT group_id FROM tabs WHERE name LIKE %~like~', $tab);
-            return $row ? $row['group_id'] : 0;
-        } catch (\Dibi\Exception $e) {
-            writeLog('error', 'Tab Group Function - Error Fetching Tab Group', $tab);
-            return 0;
-        }
-
+function getTabGroup ($tab)
+{
+    try {
+        $connect = new Dibi\Connection([
+            'driver' => 'sqlite3',
+            'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],]);
+        $row = $connect->fetch('SELECT group_id FROM tabs WHERE name LIKE %~like~', $tab);
+        return $row ? $row['group_id'] : 0;
+    } catch (\Dibi\Exception $e) {
+        writeLog('error', 'Tab Group Function - Error Fetching Tab Group', $tab);
+        return 0;
     }
+}
 
 function logoOrText()
 {

--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1656,7 +1656,7 @@ function auth()
 			    'driver' => 'sqlite3',
 			    'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],
 		    ]);
-            $row = $connect->fetch('SELECT group_id FROM tabs WHERE name = %~like~', $tab);
+            $row = $connect->fetch('SELECT group_id FROM tabs WHERE name LIKE %~like~', $tab);
             return $row ? $row['group_id'] : 0;
         } catch (\Dibi\Exception $e) {
             writeLog('error', 'Tab Group Function - Error Fetching Tab Group', $tab);

--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1608,7 +1608,15 @@ function auth()
 	$ban = isset($_GET['ban']) ? strtoupper($_GET['ban']) : "";
 	$whitelist = isset($_GET['whitelist']) ? $_GET['whitelist'] : false;
 	$blacklist = isset($_GET['blacklist']) ? $_GET['blacklist'] : false;
-	$group = isset($_GET['group']) ? (int)$_GET['group'] : (int)0;
+    $group = 0;
+    $groupParam = $_GET['group'];
+    if(isset($groupParam)) {
+        if (is_numeric($groupParam)) {
+            $group = (int)$groupParam;
+        } else {
+            $group = getTabGroup($groupParam);
+        }
+    }
 	$currentIP = userIP();
 	$unlocked = ($GLOBALS['organizrUser']['locked'] == '1') ? false : true;
 	if (isset($GLOBALS['organizrUser'])) {
@@ -1640,6 +1648,22 @@ function auth()
 		!$debug ? exit(http_response_code(401)) : die("Not Authorized Due To No Parameters Set");
 	}
 }
+
+    function getTabGroup ($tab)
+    {
+        try {
+            $connect = new Dibi\Connection([
+                                               'driver'   => 'sqlite3',
+                                               'database' => $GLOBALS['dbLocation'] . $GLOBALS['dbName'],
+                                           ]);
+            $all = $connect->fetch("SELECT group_id FROM tabs WHERE name = '%?%'", $tab);
+            return $all ? $all['group_id'] : 0;
+        } catch (\Dibi\Exception $e) {
+            writeLog('error', 'Tab Group Function - Error Fetching Tab Alias', $tab);
+            return 0;
+        }
+
+    }
 
 function logoOrText()
 {


### PR DESCRIPTION
You can handle this however you want, basically just wanted the front end to determine permissions for tabs rather than setting permissions in nginx. Best practice would be to add another column into the `tabs` table to give an auth alias rather than just using the tab name.

The new nginx setup would look something like this:
```
location ~ /auth-([a-zA-Z0-9]+) {
    # This is used for Organizr V2
    internal;
    include /config/nginx/proxy.conf;
    resolver 127.0.0.11 valid=30s;
    set $upstream_organizr organizr;
    proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
    proxy_set_header Content-Length "";
}
```

Finally, an example of how to use it for sonarr:
```
location ^~ /sonarr {
    auth_request /auth-sonarr;  #=sonarr must match with the name of the tab, case insensitive

    include /config/nginx/proxy.conf;
    resolver 127.0.0.11 valid=30s;
    set $upstream_sonarr sonarr;
    proxy_pass http://$upstream_sonarr:8989;
}
```
