### PR TITLE
if using Traefik, redirect 401 errors to login page

### DIFF
--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -1666,15 +1666,19 @@ function auth()
 		}
 	}
 	if ($group !== null) {
+		if ($_SERVER['HTTP_X_FORWARDED_SERVER'] == 'traefik' && $_SERVER['HTTP_X_FORWARDED_PROTO'] && $_SERVER['HTTP_X_FORWARDED_HOST']) {
+			$redirect_header = 'Location: ' . $_SERVER['HTTP_X_FORWARDED_PROTO'] . '://' . $_SERVER['HTTP_X_FORWARDED_HOST'] . $_SERVER['HTTP_X_FORWARDED_PREFIX'] . '/';
+		}
+
 		if (qualifyRequest($group) && $unlocked) {
 			header("X-Organizr-User: $currentUser");
 			header("X-Organizr-Email: $currentEmail");
 			!$debug ? exit(http_response_code(200)) : die("$userInfo Authorized");
 		} else {
-			!$debug ? exit(http_response_code(401)) : die("$userInfo Not Authorized");
+			!$debug ? exit(http_response_code(401) . header($redirect_header)) : die("$userInfo Not Authorized");
 		}
 	} else {
-		!$debug ? exit(http_response_code(401)) : die("Not Authorized Due To No Parameters Set");
+		!$debug ? exit(http_response_code(401). header($redirect_header)) : die("Not Authorized Due To No Parameters Set");
 	}
 }
 


### PR DESCRIPTION
If using Traefik, a forwardauth request that results in 401 will be passed through to the browser. This PR  checks for the presence of Traefik reverse proxy headers and sets a location header to redirect the browser to the main Organizr page, where the user can then authenticate.