### PR TITLE
Grab monitorr icons in Org

### DIFF
--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -2578,12 +2578,10 @@ function getMonitorr()
 					$imageUrl = $url . '/assets' . $image;
 
 					$cacheDirectory = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR;
-					$cacheImage = $cacheDirectory . 'monitorr-' . $image;
 
 					$img = Requests::get($imageUrl, [ 'Token' => $GLOBALS['organizrAPI'] ], []);
 					if($img->success) {
 						$base64 = 'data:image/' . $ext . ';base64,' . base64_encode($img->body);
-						// $statuses[$service]['image'] = '/plugins/images/cache/monitorr-' . $service . '.' . $ext;
 						$statuses[$service]['image'] = $base64;
 					} else {
 						$statuses[$service]['image'] = $cacheDirectory . 'no-list.png';

--- a/api/functions/homepage-connect-functions.php
+++ b/api/functions/homepage-connect-functions.php
@@ -2572,7 +2572,22 @@ function getMonitorr()
 							$image = $match;
 						}
 					}
-					$statuses[$service]['image'] = $url . '/assets' . $image;
+					$ext = explode('.', $image);
+					$ext = $ext[key(array_slice($ext, -1, 1, true))];
+
+					$imageUrl = $url . '/assets' . $image;
+
+					$cacheDirectory = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'images' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR;
+					$cacheImage = $cacheDirectory . 'monitorr-' . $image;
+
+					$img = Requests::get($imageUrl, [ 'Token' => $GLOBALS['organizrAPI'] ], []);
+					if($img->success) {
+						$base64 = 'data:image/' . $ext . ';base64,' . base64_encode($img->body);
+						// $statuses[$service]['image'] = '/plugins/images/cache/monitorr-' . $service . '.' . $ext;
+						$statuses[$service]['image'] = $base64;
+					} else {
+						$statuses[$service]['image'] = $cacheDirectory . 'no-list.png';
+					}
 				}
 
 				ksort($statuses);

--- a/js/functions.js
+++ b/js/functions.js
@@ -6752,7 +6752,7 @@ function buildMonitorrItem(array){
 
     .monitorr-card img {
         max-height: 100px;
-        max-width: 100%;]
+        max-width: 100%;
     }
 
     .monitorr-card .indicator {


### PR DESCRIPTION
Grab images in Org, then return that image to front-end (Allows using local IP:PORT for monitorr rather than RP url)

Currently grabs the image from monitorr by get request, then returns base64 encoded image data to front-end which is used as src. 

I didn't use the `cacheImage()` function, as using that with the RP url will return a 401 error as you need to set the org API token in the headers.