### PR TITLE
Added ability to set allow-downloads iframe sandbox options

### DIFF
--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -825,6 +825,10 @@ function getSettingsMain()
 						'name' => 'Allow Top Navigation',
 						'value' => 'allow-top-navigation'
 					),
+					array(
+						'name' => 'Allow Downloads',
+						'value' => 'allow-downloads'
+					),
 				)
 			),
 			array(


### PR DESCRIPTION
According to https://www.chromestatus.com/feature/5706745674465280
chrome will remove the ability to download from iframe unless the
embedder adds support for it through the "allow-downloads" sandbox
option, this option will become needed in chrome 83, which is scheduled
for May 19 2020.