### PR TITLE
Add /token/validate v2 API endpoint

### DIFF
--- a/api/v2/routes/token.php
+++ b/api/v2/routes/token.php
@@ -9,3 +9,14 @@ $app->delete('/token/{id}', function ($request, $response, $args) {
 		->withHeader('Content-Type', 'application/json;charset=UTF-8')
 		->withStatus($GLOBALS['responseCode']);
 });
+
+$app->post('/token/validate', function ($request, $response, $args) {
+        $Organizr = ($request->getAttribute('Organizr')) ?? new Organizr();
+        if ($Organizr->qualifyRequest(999, true)) {
+                $GLOBALS['api']['response']['data'] = $Organizr->jwtParse($_REQUEST["Token"]);
+        }
+        $response->getBody()->write(jsonE($GLOBALS['api']));
+        return $response
+                ->withHeader('Content-Type', 'application/json;charset=UTF-8')
+                ->withStatus($GLOBALS['responseCode']);
+});


### PR DESCRIPTION
Adds an additional API endpoint to the v2 API to provide the ability to externally validate Organizr JWT tokens to support custom SSO applications.

You kindly previously implemented on v1 of the API after I asked on Discord if this could be added. Didn't catch your messages about breaking changes in the new API, so hopefully this can just be bolted back on!

I've not spent too much time reviewing the changes in the new v2 API, so there may well be a better place and way to do this. My specific use case is to allow PHP apps behind Organizr to take the token and validate it without having to know the JWT secret. Once validated, Organizr returns the user information for that token and allows custom Single-Sign-On.

An example of how I use this is included below;
````
### ORGANIZR CONFIG ###
$Organizr_Cookie = "organizr_token_uid"; // Organizr Token cookie name
$Organizr_URL = "http://organizr-server/"; // The URL of Organizr
### ORGANIZR CONFIG ###

################################## Organizr ##################################
# Set Authentication as Organizr if defined.
################################## Organizr ##################################
if (isset($_COOKIE[$Organizr_Cookie])) {
	$post = [
		'Token' => $_COOKIE[$Organizr_Cookie],
	];
		
	$ch = curl_init($Organizr_URL . "/api/v2/token/validate");
	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
	curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
	$response = curl_exec($ch);
	curl_close($ch);
	$response = json_decode($response);
		
	if ($response->response->data->valid)
	{
		$GLOBALS['User'] = [
			'Username' => $response->response->data->username,
			'Email' => $response->response->data->email,
			'group' => $response->response->data->group,
			'groupID' => $response->response->data->groupID,
			'userID' => $response->response->data->userID,
			'image' => $response->response->data->image,
		];				
	}
}	
````