### PR TITLE
Monitorr plugin does not work on unresponsive services, if they have no service-link associated.

### DIFF
--- a/api/homepage/monitorr.php
+++ b/api/homepage/monitorr.php
@@ -124,30 +124,28 @@ trait MonitorrHomepageItem
 				// This section grabs the names of all services by regex
 				$services = [];
 				$servicesMatch = [];
-				$servicePattern = '/<div id="servicetitle"><div>(.*)<\/div><\/div><div class="btnonline">Online<\/div><\/a><\/div><\/div>|<div id="servicetitleoffline".*><div>(.*)<\/div><\/div><div class="btnoffline".*>Offline<\/div><\/div><\/div>|<div id="servicetitlenolink".*><div>(.*)<\/div><\/div><div class="btnonline".*>Online<\/div><\/div><\/div>|<div id="servicetitle"><div>(.*)<\/div><\/div><div class="btnunknown">/';
+				$servicePattern = '/<div id="servicetitle(?:offline|nolink)?".*><div>(.*)<\/div><\/div><div class="(?:btnonline|btnoffline|btnunknown)".*>(Online|Offline|Unresponsive)<\/div>(:?<\/a>)?<\/div><\/div>/';
 				preg_match_all($servicePattern, $html, $servicesMatch);
-				$services = array_filter($servicesMatch[1]) + array_filter($servicesMatch[2]) + array_filter($servicesMatch[3]) + array_filter($servicesMatch[4]);
+				$services = array_filter($servicesMatch[1]);
+                $status = array_filter($servicesMatch[2]);
 				$statuses = [];
 				foreach ($services as $key => $service) {
-					$statusPattern = '/' . $service . '<\/div><\/div><div class="btnonline">(Online)<\/div>|' . $service . '<\/div><\/div><div class="btnoffline".*>(Offline)<\/div><\/div><\/div>|' . $service . '<\/div><\/div><div class="btnunknown">(.*)<\/div><\/a>/';
-					$status = [];
-					preg_match($statusPattern, $html, $status);
-					$statuses[$service] = $status;
-					foreach ($status as $match) {
-						if ($match == 'Online') {
-							$statuses[$service] = [
-								'status' => true
-							];
-						} else if ($match == 'Offline') {
-							$statuses[$service] = [
-								'status' => false
-							];
-						} else if ($match == 'Unresponsive') {
-							$statuses[$service] = [
-								'status' => 'unresponsive'
-							];
-						}
-					}
+					$match = $status[$key];
+					$statuses[$service] = $match;
+                    if ($match == 'Online') {
+                        $statuses[$service] = [
+                            'status' => true
+                        ];
+                    } else if ($match == 'Offline') {
+                        $statuses[$service] = [
+                            'status' => false
+                        ];
+                    } else if ($match == 'Unresponsive') {
+                        $statuses[$service] = [
+                            'status' => 'unresponsive'
+                        ];
+                    }
+
 					$statuses[$service]['sort'] = $key;
 					$imageMatch = [];
 					$imgPattern = '/assets\/img\/\.\.(.*)" class="serviceimg" alt=.*><\/div><\/div><div id="servicetitle"><div>' . $service . '|assets\/img\/\.\.(.*)" class="serviceimg imgoffline" alt=.*><\/div><\/div><div id="servicetitleoffline".*><div>' . $service . '|assets\/img\/\.\.(.*)" class="serviceimg" alt=.*><\/div><\/div><div id="servicetitlenolink".*><div>' . $service . '/';


### PR DESCRIPTION
<!-- Please Fill out as much information as possible, Thanks! -->
###### Organizr Version: V 2.1.0
###### Branch: Develop
###### WebServer: Nginx
###### Operating System: Debian
<hr>

##### Problem Description:
Monitorr plugin drops unresponsive services, if they are created with "Check Type: Standard" and "Link enabled: No".

<hr>

##### Reproduction Steps:
1) Create a service in monitorr to a backend, which returns a http errorcode (e.g. 500 internal server error) but is "pingable"
2) Set "Link Enabled" to "No" and select "Check Type: Standard"
2) Make sure that this service returns "Unresponsive" inside monitorr

<hr>

#### Errors on screen?  If so paste here:
The service will not appear in organizr because of a missing pattern to match for services with "Link enabled: No" while being unresponsive.

Fix: See my pullrequest. I compactified the regexp pattern to match online, offline, unresponsive services, no matter if a link is associated to them or not.

```

```
