### PR TITLE
Implemented Jellyfin SSO workaround

### DIFF
--- a/api/classes/organizr.class.php
+++ b/api/classes/organizr.class.php
@@ -2302,6 +2302,22 @@ class Organizr
 					'label' => 'Enable',
 					'value' => $this->config['ssoOmbi']
 				)
+			),
+			'Jellyfin' => array(
+				array(
+					'type' => 'input',
+					'name' => 'jellyfinURL',
+					'label' => 'Jellyfin URL',
+					'value' => $this->config['jellyfinURL'],
+					'help' => 'Please make sure to use the same (sub)domain to access Jellyfin as Organizr\'s',
+					'placeholder' => 'http(s)://hostname:port'
+				),
+				array(
+					'type' => 'switch',
+					'name' => 'ssoJellyfin',
+					'label' => 'Enable',
+					'value' => $this->config['ssoJellyfin']
+				)
 			)
 		);
 	}

--- a/api/config/default.php
+++ b/api/config/default.php
@@ -56,6 +56,7 @@ return array(
 	'ssoPlex' => false,
 	'ssoOmbi' => false,
 	'ssoTautulli' => false,
+	'ssoJellyfin' => false,
 	'sonarrURL' => '',
 	'sonarrUnmonitored' => false,
 	'sonarrToken' => '',

--- a/api/v2/routes/root.php
+++ b/api/v2/routes/root.php
@@ -116,7 +116,8 @@ $app->get('/launch', function ($request, $response, $args) {
 	$GLOBALS['api']['response']['data']['status'] = $Organizr->status();
 	$GLOBALS['api']['response']['data']['sso'] = array(
 		'myPlexAccessToken' => isset($_COOKIE['mpt']) ? $_COOKIE['mpt'] : false,
-		'id_token' => isset($_COOKIE['Auth']) ? $_COOKIE['Auth'] : false
+		'id_token' => isset($_COOKIE['Auth']) ? $_COOKIE['Auth'] : false,
+		'jellyfin_credentials' => isset($_COOKIE['jellyfin_credentials']) ? $_COOKIE['jellyfin_credentials'] : false
 	);
 	$response->getBody()->write(jsonE($GLOBALS['api']));
 	return $response


### PR DESCRIPTION
As discussed in the Issues  ( https://github.com/causefx/Organizr/issues/1521 ), managed to implement a working workaround / pseudo sso for Jellyfin with minimal limitations or better said prerequisites. (Namely having a Jellyfin access on the same subdomain)

Implemented:
* SSO config page user interface
* SSO backend functions

Tested with newest Organizr + Jellyfin base Docker images as of 2020/11/25