### PR TITLE
implemented Jellyfin pseudo-sso

### DIFF
--- a/api/classes/organizr.class.php
+++ b/api/classes/organizr.class.php
@@ -2302,6 +2302,22 @@ class Organizr
 					'label' => 'Enable',
 					'value' => $this->config['ssoOmbi']
 				)
+			),
+			'Jellyfin' => array(
+				array(
+					'type' => 'input',
+					'name' => 'jellyfinURL',
+					'label' => 'Jellyfin URL',
+					'value' => $this->config['jellyfinURL'],
+					'help' => 'Please make sure to use the same (sub)domain to access Jellyfin as Organizr\'s',
+					'placeholder' => 'http(s)://hostname:port'
+				),
+				array(
+					'type' => 'switch',
+					'name' => 'ssoJellyfin',
+					'label' => 'Enable',
+					'value' => $this->config['ssoJellyfin']
+				)
 			)
 		);
 	}

--- a/api/functions/auth-functions.php
+++ b/api/functions/auth-functions.php
@@ -434,7 +434,7 @@ trait AuthFunctions
 	public function plugin_auth_jellyfin($username, $password)
 	{
 		try {
-			$url = $this->qualifyURL($this->config['embyURL']) . '/Users/authenticatebyname';
+			$url = $this->qualifyURL($this->config['jellyfinURL']) . '/Users/authenticatebyname';
 			$headers = array(
 				'X-Emby-Authorization' => 'MediaBrowser Client="Organizr Auth", Device="Organizr", DeviceId="orgv2", Version="2.0"',
 				'Content-Type' => 'application/json',
@@ -453,7 +453,7 @@ trait AuthFunctions
 						'X-Emby-Authorization' => 'MediaBrowser Client="Organizr Auth", Device="Organizr", DeviceId="orgv2", Version="2.0", Token="' . $json['AccessToken'] . '"',
 						'Content-Type' => 'application/json',
 					);
-					$response = Requests::post($this->qualifyURL($this->config['embyURL']) . '/Sessions/Logout', $headers, array());
+					$response = Requests::post($this->qualifyURL($this->config['jellyfinURL']) . '/Sessions/Logout', $headers, array());
 					if ($response->success) {
 						return true;
 					}

--- a/api/v2/routes/root.php
+++ b/api/v2/routes/root.php
@@ -116,7 +116,8 @@ $app->get('/launch', function ($request, $response, $args) {
 	$GLOBALS['api']['response']['data']['status'] = $Organizr->status();
 	$GLOBALS['api']['response']['data']['sso'] = array(
 		'myPlexAccessToken' => isset($_COOKIE['mpt']) ? $_COOKIE['mpt'] : false,
-		'id_token' => isset($_COOKIE['Auth']) ? $_COOKIE['Auth'] : false
+		'id_token' => isset($_COOKIE['Auth']) ? $_COOKIE['Auth'] : false,
+		'jellyfin_credentials' => isset($_COOKIE['jellyfin_credentials']) ? $_COOKIE['jellyfin_credentials'] : false
 	);
 	$response->getBody()->write(jsonE($GLOBALS['api']));
 	return $response


### PR DESCRIPTION
Resubmitting to develop branch

---
As discussed in the Issues  ( https://github.com/causefx/Organizr/issues/1521 ), managed to implement a working workaround / pseudo sso for Jellyfin with minimal limitations or better said prerequisites. (Namely having a Jellyfin access on the same subdomain)

Implemented:
* SSO config page user interface
* SSO backend functions

Tested with newest Organizr + Jellyfin base Docker images as of 2020/11/25