### PR TITLE
Fixes causefx/Organizr#1544

### DIFF
--- a/api/classes/organizr.class.php
+++ b/api/classes/organizr.class.php
@@ -2964,8 +2964,7 @@ class Organizr
 				if ($createToken) {
 					$this->writeLoginLog($username, 'success');
 					$this->writeLog('success', 'Login Function - A User has logged in', $username);
-					$ssoUser = ((empty($result['email'])) ? $result['username'] : (strpos($result['email'], 'placeholder') !== false)) ? $result['username'] : $result['email'];
-					$this->ssoCheck($ssoUser, $password, $token); //need to work on this
+					$this->ssoCheck($result, $password, $token); //need to work on this
 					return ($output) ? array('name' => $this->cookieName, 'token' => (string)$createToken) : true;
 				} else {
 					$this->setAPIResponse('error', 'Token creation error', 500);


### PR DESCRIPTION
resolves causefx/Organizr#1544

As discussed in the issue now instead of deciding in the organizr.class.php file and passing only username or email as the ssoUsername I passed the whole userobject and created a modular mapping inside sso-functions.php.

Fixes an issue where Jellyin-SSO, Ombi-SSO and possibly other SSO function users could not properly use the SSO functionality unless they cleared/removed their Organizr user's email, or changed it to be their username.