### PR TITLE
Add stale workflows

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,14 @@
+name: Lock closed stale issue
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  lock:
+    if: github.event.label.name == 'closed-no-issue-activity'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: OSDKDev/lock-issues@v1.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          close-issue-message: "This issue has been closed due to lack of activity, if this issue still persists, please re-open it."
+          close-issue-label: "closed-no-issue-activity"
+          stale-issue-label: "no-issue-activity"
+          days-before-stale: 15
+          days-before-close: 90


### PR DESCRIPTION
Automatically marks issues as stale after 15 days without activity, closes and locks after 90 days of inactivity.