### PR TITLE
Update Overseerr Plex auth endpoint

### DIFF
--- a/api/functions/sso-functions.php
+++ b/api/functions/sso-functions.php
@@ -171,7 +171,7 @@ trait SSOFunctions
 				//"password" => ($oAuthToken ? "" : $password), // not needed yet
 				"authToken" => $oAuthToken
 			);
-			$endpoint = '/api/v1/auth/login';
+			$endpoint = '/api/v1/auth/plex';
 			$options = $this->requestOptions($url, false, 60);
 			$response = Requests::post($url . $endpoint, $headers, json_encode($data), $options);
 			if ($response->success) {


### PR DESCRIPTION
Overseerr's Plex auth endpoint is being renamed from `/auth/login` to `/auth/plex` in sct/overseerr#949.  The Overseerr SSO function will need to be updated to use the new endpoint once that PR has been approved and merged.