### PR TITLE
Fix username in overseerr SSO logs

### DIFF
--- a/api/functions/sso-functions.php
+++ b/api/functions/sso-functions.php
@@ -177,7 +177,7 @@ trait SSOFunctions
 			if ($response->success) {
 				$user = json_decode($response->body, true); // not really needed yet
 				$token = $response->cookies['connect.sid']->value;
-				$this->writeLog('success', 'Overseerr Token Function - Grabbed token', $user['username']);
+				$this->writeLog('success', 'Overseerr Token Function - Grabbed token', $username);
 			} else {
 				if ($fallback) {
 					$this->writeLog('error', 'Overseerr Token Function - Overseerr did not return Token - Will retry using fallback credentials', $username);


### PR DESCRIPTION
Username was being reported as Guest, this is to report the correct username in the logs.

** Old **
![image](https://user-images.githubusercontent.com/51195492/108997494-91038b80-7697-11eb-84d9-7ceb6f145c8f.png)

** New **
![image](https://user-images.githubusercontent.com/51195492/108997559-a2e52e80-7697-11eb-9be9-cd6eab852858.png)
