### PR TITLE
Fix username in overseerr SSO logs

### DIFF
--- a/api/functions/sso-functions.php
+++ b/api/functions/sso-functions.php
@@ -177,7 +177,7 @@ trait SSOFunctions
 			if ($response->success) {
 				$user = json_decode($response->body, true); // not really needed yet
 				$token = $response->cookies['connect.sid']->value;
-				$this->writeLog('success', 'Overseerr Token Function - Grabbed token', $user['username']);
+				$this->writeLog('success', 'Overseerr Token Function - Grabbed token', $user['plexUsername']);
 			} else {
 				if ($fallback) {
 					$this->writeLog('error', 'Overseerr Token Function - Overseerr did not return Token - Will retry using fallback credentials', $username);


### PR DESCRIPTION
Re-submit of [PR#1598](https://github.com/causefx/Organizr/pull/1598)

Username was being reported as Guest, this is to report the correct username in the logs, was receiving null value from $user['username'] as Plex usernames from Overseerr API uses $user['plexUsername']

Example response from Overseerr **/api/v1/auth/plex**;

````
{
    "permissions": 2,
    "id": 1,
    "plexUsername": "TehMuffinMoo",
    "username": null,
    "recoveryLinkExpirationDate": null,
    "userType": 1,
    "avatar": "https://plex.tv/users/dgerrgrdg/avatar?c=5841564",
    "createdAt": "2021-02-23T22:27:44.000Z",
    "updatedAt": "2021-02-24T13:23:53.000Z",
    "settings": null,
    "requestCount": 1,
    "displayName": "TehMuffinMoo",
    "plexToken": "Token",
    "password": null,
    "resetPasswordGuid": null,
    "plexId": null
}
````

Not sure if the intention is to keep the username being reported back from Overseerr, would make sense to make sure that the username is correctly matching I suppose. But everything else is just using the **$username** variable so happy updating PR if this is preferred.

** Old **
![image](https://user-images.githubusercontent.com/51195492/108997494-91038b80-7697-11eb-84d9-7ceb6f145c8f.png)

** New **
![image](https://user-images.githubusercontent.com/51195492/108997559-a2e52e80-7697-11eb-9be9-cd6eab852858.png)