### PR TITLE
Update healthChecks.php

### DIFF
--- a/api/plugins/healthChecks.php
+++ b/api/plugins/healthChecks.php
@@ -72,7 +72,7 @@ class HealthChecks extends Organizr
 	
 	public function _healthCheckPluginUUID($uuid, $pass = false)
 	{
-		if (!$uuid || !$pass || $this->config['HEALTHCHECKS-PingURL'] == '') {
+		if (!$uuid || $this->config['HEALTHCHECKS-PingURL'] == '') {
 			return false;
 		}
 		$url = $this->qualifyURL($this->config['HEALTHCHECKS-PingURL']);
@@ -134,7 +134,7 @@ class HealthChecks extends Organizr
 						$pass = true;
 					}
 				}
-				$this->_healthCheckPluginUUID($v['UUID'], 'true');
+				$this->_healthCheckPluginUUID($v['UUID'], $pass);
 			}
 			$this->setAPIResponse('success', null, 200, $allItems);
 		} else {


### PR DESCRIPTION
Updates to _healthCheckPluginRun() and _healthCheckPluginUUID to properly pass the result of $pass and allow sending of "/fail" to tell Healthchecks.io that the job has failed in real-time.