### PR TITLE
Quick fix to allow non-admins to view bookmarks

### DIFF
--- a/api/plugins/api/bookmark.php
+++ b/api/plugins/api/bookmark.php
@@ -14,7 +14,7 @@ $app->get('/plugins/bookmark/settings', function ($request, $response, $args) {
 $app->get('/plugins/bookmark/page', function ($request, $response, $args) {
 	$Bookmark = new Bookmark();
 	if ($Bookmark->_checkRequest($request) && $Bookmark->checkRoute($request)) {
-		if ($Bookmark->qualifyRequest(1, true)) {
+		if ($Bookmark->qualifyRequest(4, true)) {
 			$GLOBALS['api']['response']['data'] = $Bookmark->_getPage();
 		}
 	}


### PR DESCRIPTION
There is probably a better way to fix this, but it looks like by closing off the /plugins/bookmark/page endpoint to Admins (1) prevented non-admins from viewing the bookmarks page.