### PR TITLE
Update magnific-popup.css

### DIFF
--- a/plugins/bower_components/Magnific-Popup-master/dist/magnific-popup.css
+++ b/plugins/bower_components/Magnific-Popup-master/dist/magnific-popup.css
@@ -18,6 +18,7 @@
   z-index: 1043;
   position: fixed;
   outline: none !important;
+  overflow-y: auto;
   -webkit-backface-visibility: hidden; }
 
 .mfp-container {


### PR DESCRIPTION
Adding explicit overflow-y style to mfp-wrap. Scrolling wasn't available for longer modals on certain mobile browsers, like Samsung Internet.