### PR TITLE
Update healthChecks.php

### DIFF
--- a/api/plugins/healthChecks.php
+++ b/api/plugins/healthChecks.php
@@ -52,7 +52,7 @@ class HealthChecks extends Organizr
 	public function _healthCheckPluginTest($url)
 	{
 		$success = false;
-		$options = array('verify' => false, 'verifyname' => false, 'follow_redirects' => true, 'redirects' => 1);
+		$options = array('verify' => false, 'verifyname' => false, 'follow_redirects' => true, 'redirects' => 10);
 		$headers = array('Token' => $this->config['organizrAPI']);
 		$url = $this->qualifyURL($url);
 		try {


### PR DESCRIPTION
Suggesting bumping up Requests redirect limit to Requests for PHP's default of 10 due to 1 returning false errors for reverse proxies with login redirects like Jackett, Radarr, etc.