### PR TITLE
Add custom timeout to healthchecks API

### DIFF
--- a/api/plugins/healthChecks.php
+++ b/api/plugins/healthChecks.php
@@ -136,6 +136,11 @@ class HealthChecks extends Organizr
 					unset($allItems[$k]);
 				}
 			}
+			$limit = 30;
+			if (count($allItems) > 0){
+				$limit = count($allItems) * 20;
+			}
+			set_time_limit($limit);
 			foreach ($allItems as $k => $v) {
 				$testLocal = $v['Internal URL'] !== '' ?? false;
 				$testExternal = $v['External URL'] !== '' ?? false;

--- a/api/plugins/healthChecks.php
+++ b/api/plugins/healthChecks.php
@@ -137,7 +137,7 @@ class HealthChecks extends Organizr
 				}
 			}
 			$limit = 30;
-			if (count($allItems) > 0){
+			if (!empty($allItems)){
 				$limit = count($allItems) * 20;
 			}
 			set_time_limit($limit);


### PR DESCRIPTION
The default PHP timeout is 30 seconds. The default timeout for request.php is 10 seconds. If you have too many items set or connection takes longer than usual, healthchecks/run will return a 500 error. I propose using set_time_limit to temporarily override the timeout with a total amount of seconds calculated based on number of items in $allItems array multiples by 20 (to account for internal and external).