### PR TITLE
Remove "Jellyfin Tab WAN URL" from Jellyfin homepage integration

### DIFF
--- a/api/config/default.php
+++ b/api/config/default.php
@@ -42,7 +42,6 @@ return array(
 	'embyTabName' => '',
 	'embyURL' => '',
 	'embyToken' => '',
-	'jellyfinTabURL' => '',
 	'jellyfinTabName' => '',
 	'jellyfinURL' => '',
 	'jellyfinToken' => '',

--- a/api/homepage/jellyfin.php
+++ b/api/homepage/jellyfin.php
@@ -127,13 +127,6 @@ trait JellyfinHomepageItem
 						'placeholder' => 'Only use if you have Jellyfin in a reverse proxy'
 					),
 					array(
-						'type' => 'input',
-						'name' => 'jellyfinTabURL',
-						'label' => 'Jellyfin Tab WAN URL',
-						'value' => $this->config['jellyfinTabURL'],
-						'placeholder' => 'http(s)://hostname:port'
-					),
-					array(
 						'type' => 'select',
 						'name' => 'cacheImageSize',
 						'label' => 'Image Cache Size',
@@ -560,7 +553,7 @@ trait JellyfinHomepageItem
 		$jellyfinItem['address'] = $this->userDefinedIdReplacementLink($this->config['homepageJellyfinLink'], $jellfinVariablesForLink);
 		$jellyfinItem['nowPlayingOriginalImage'] = 'api/v2/homepage/image?source=jellyfin&type=' . $jellyfinItem['nowPlayingImageType'] . '&img=' . $jellyfinItem['nowPlayingThumb'] . '&height=' . $nowPlayingHeight . '&width=' . $nowPlayingWidth . '&key=' . $jellyfinItem['nowPlayingKey'] . '$' . $this->randString();
 		$jellyfinItem['originalImage'] = 'api/v2/homepage/image?source=jellyfin&type=' . $jellyfinItem['imageType'] . '&img=' . $jellyfinItem['thumb'] . '&height=' . $height . '&width=' . $width . '&key=' . $jellyfinItem['key'] . '$' . $this->randString();
-		$jellyfinItem['openTab'] = $this->config['jellyfinTabURL'] && $this->config['jellyfinTabName'] ? true : false;
+		$jellyfinItem['openTab'] = $this->config['jellyfinTabName'];
 		$jellyfinItem['tabName'] = $this->config['jellyfinTabName'] ? $this->config['jellyfinTabName'] : '';
 		// Stream info
 		$jellyfinItem['userStream'] = array(


### PR DESCRIPTION
The "Jellyfin Tab WAN URL" field isn't reference anywhere except for an additional non-empty check for the open tab setting. I've removed it to prevent confusion when setting up Jellyfin homepage integration.