### PR TITLE
Adding "Target URL" under Homepage Item > Calendar Settings

### DIFF
--- a/api/functions/option-functions.php
+++ b/api/functions/option-functions.php
@@ -447,6 +447,14 @@ trait OptionsFunction
 					'attr' => 'data-original="' . $this->config[$name] . '"'
 				];
 				break;
+			case 'calendarlinkurl':
+				$settingMerge = [
+					'type' => 'select',
+					'label' => 'Target URL',
+					'help' => 'Set the primary URL used when clicking on calendar icon.',
+					'options' => $this->makeOptionsFromValues($this->config[str_replace('CalendarLink','',$name).'URL'], true, 'Use Default'),
+				];
+				break;
 			default:
 				$settingMerge = [
 					'type' => strtolower($type),
@@ -465,7 +473,14 @@ trait OptionsFunction
 
 	public function makeOptionsFromValues($values = null)
 	{
-		$formattedValues = [];
+		if ($appendBlank === true){
+			$formattedValues[] = [
+				'name' => (!empty($blankLabel)) ? $blankLabel : 'Select option...',
+				'value' => ''
+			];
+		} else {
+			$formattedValues = [];
+		}
 		if (strpos($values, ',') !== false) {
 			$explode = explode(',', $values);
 			foreach ($explode as $item) {

--- a/api/functions/option-functions.php
+++ b/api/functions/option-functions.php
@@ -471,7 +471,7 @@ trait OptionsFunction
 		return $setting;
 	}
 
-	public function makeOptionsFromValues($values = null)
+	public function makeOptionsFromValues($values = null, $appendBlank = null, $blankLabel = null)
 	{
 		if ($appendBlank === true){
 			$formattedValues[] = [

--- a/api/homepage/lidarr.php
+++ b/api/homepage/lidarr.php
@@ -42,6 +42,7 @@ trait LidarrHomepageItem
 					$this->settingsOption('calendar-locale', 'calendarLocale'),
 					$this->settingsOption('calendar-limit', 'calendarLimit'),
 					$this->settingsOption('refresh', 'calendarRefresh'),
+					$this->settingsOption('calendar-link-url', 'lidarrCalendarLink'),
 				],
 				'Test Connection' => [
 					$this->settingsOption('blank', null, ['label' => 'Please Save before Testing']),
@@ -237,10 +238,13 @@ trait LidarrHomepageItem
 					$fanart = str_replace('http://', 'https://', $image['url']);
 				}
 			}
-			$href = "";
-			if (!empty($this->config['lidarrURL'])){
+			$href = $this->config['lidarrCalendarLink'] ?? '';
+			if (empty($href) && !empty($this->config['lidarrURL'])){
 				$href_arr = explode(',',$this->config['lidarrURL']);
-				$href = reset($href_arr) . '/artist/' . $child['artist']['foreignArtistId'];
+				$href = reset($href_arr);
+			}
+			if (!empty($href)){
+				$href = $href . '/artist/' . $child['artist']['foreignArtistId'];
 				$href = str_replace("//artist/","/artist/",$href);
 			}
 			$details = array(

--- a/api/homepage/radarr.php
+++ b/api/homepage/radarr.php
@@ -48,6 +48,8 @@ trait RadarrHomepageItem
 					$this->settingsOption('calendar-locale', 'calendarLocale'),
 					$this->settingsOption('calendar-limit', 'calendarLimit'),
 					$this->settingsOption('refresh', 'calendarRefresh'),
+					$this->settingsOption('calendar-link-url', 'radarrCalendarLink'),
+					$this->settingsOption('blank', null),
 					$this->settingsOption('switch', 'radarrUnmonitored', ['label' => 'Show Unmonitored']),
 					$this->settingsOption('switch', 'radarrPhysicalRelease', ['label' => 'Show Physical Releases']),
 					$this->settingsOption('switch', 'radarrDigitalRelease', ['label' => 'Show Digital Releases']),
@@ -322,10 +324,13 @@ trait RadarrHomepageItem
 					}
 				}
 				$alternativeTitles = empty($alternativeTitles) ? "" : substr($alternativeTitles, 0, -2);
-				$href = "";
-				if (!empty($this->config['radarrURL'])){
+				$href = $this->config['radarrCalendarLink'] ?? '';
+				if (empty($href) && !empty($this->config['radarrURL'])){
 					$href_arr = explode(',',$this->config['radarrURL']);
-					$href = reset($href_arr) . '/movie/' . $movieID;
+					$href = reset($href_arr);
+				}
+				if (!empty($href)){
+					$href = $href . '/movie/' . $movieID;
 					$href = str_replace("//movie/","/movie/",$href);
 				}
 				$details = array(

--- a/api/homepage/sonarr.php
+++ b/api/homepage/sonarr.php
@@ -52,6 +52,7 @@ trait SonarrHomepageItem
 					$this->settingsOption('calendar-locale', 'calendarLocale'),
 					$this->settingsOption('calendar-limit', 'calendarLimit'),
 					$this->settingsOption('refresh', 'calendarRefresh'),
+					$this->settingsOption('calendar-link-url', 'sonarrCalendarLink'),
 					$this->settingsOption('switch', 'sonarrUnmonitored', ['label' => 'Show Unmonitored']),
 				],
 				'Test Connection' => [
@@ -289,10 +290,13 @@ trait SonarrHomepageItem
 				}
 			}
 			$bottomTitle = 'S' . sprintf("%02d", $child['seasonNumber']) . 'E' . sprintf("%02d", $child['episodeNumber']) . ' - ' . $child['title'];
-			$href = "";
-			if (!empty($this->config['sonarrURL'])){
+			$href = $this->config['sonarrCalendarLink'] ?? '';
+			if (empty($href) && !empty($this->config['sonarrURL'])){
 				$href_arr = explode(',',$this->config['sonarrURL']);
-				$href = reset($href_arr) . '/series/' . preg_replace('/[^A-Za-z0-9. -]/', '', preg_replace('/[[:space:]]+/', '-', $seriesName));
+				$href = reset($href_arr);
+			}
+			if (!empty($href)){
+				$href = $href . '/series/' . preg_replace('/[^A-Za-z0-9. -]/', '', preg_replace('/[[:space:]]+/', '-', $seriesName));
 				$href = str_replace("//series/","/series/",$href);
 			}
 			$details = array(

--- a/js/functions.js
+++ b/js/functions.js
@@ -6966,7 +6966,11 @@ function buildPVRLink(href, ico){
 		return `
 		<div class="btn btn-inverse waves-effect waves-light" type="button" onclick="window.open('${href}')" style="${styleOverride}"></div>
 		`;
-	} 
+	} else {
+		return `
+		 
+		`;
+	}
 }
 function buildCalendarMetadata(array){
 	var metadata = '';


### PR DESCRIPTION
This allows a user to override the default URL used when a calendar icon is clicked. The list is populated from the "Multiple URL's" list. If none is selected, it will use the first listed in "Multiple URL's".