### PR TITLE
Adding tracker_status support to Deluge homepage item

### DIFF
--- a/api/config/default.php
+++ b/api/config/default.php
@@ -149,6 +149,7 @@ return [
 	'delugePassword' => '',
 	'delugeHideSeeding' => false,
 	'delugeHideCompleted' => false,
+	'delugeHideStatus' => true,
 	'delugeCombine' => false,
 	'delugeRefresh' => '60000',
 	'delugeDisableCertCheck' => false,

--- a/api/functions/option-functions.php
+++ b/api/functions/option-functions.php
@@ -287,6 +287,12 @@ trait OptionsFunction
 					'label' => 'Hide Completed',
 				];
 				break;
+			case 'hidestatus':
+				$settingMerge = [
+					'type' => 'switch',
+					'label' => 'Hide Status',
+				];
+				break;
 			case 'limit':
 				$settingMerge = [
 					'type' => 'number',

--- a/api/homepage/deluge.php
+++ b/api/homepage/deluge.php
@@ -52,8 +52,9 @@ trait DelugeHomepageItem
 				'Misc Options' => [
 					$this->settingsOption('hide-seeding', 'delugeHideSeeding'),
 					$this->settingsOption('hide-completed', 'delugeHideCompleted'),
-					$this->settingsOption('refresh', 'delugeRefresh'),
+					$this->settingsOption('hide-status', 'delugeHideStatus'),
 					$this->settingsOption('combine', 'delugeCombine'),
+					$this->settingsOption('refresh', 'delugeRefresh'),
 				],
 				'Test Connection' => [
 					$this->settingsOption('blank', null, ['label' => 'Please Save before Testing. Note that using a blank password might not work correctly.']),
@@ -128,7 +129,7 @@ trait DelugeHomepageItem
 		try {
 			$options = $this->requestOptions($this->config['delugeURL'], $this->config['delugeRefresh'], $this->config['delugeDisableCertCheck'], $this->config['delugeUseCustomCertificate'], ['organizr_cert' => $this->getCert(), 'custom_cert' => $this->getCustomCert()]);
 			$deluge = new deluge($this->config['delugeURL'], $this->decrypt($this->config['delugePassword']),$options);
-			$torrents = $deluge->getTorrents(null, 'comment, download_payload_rate, eta, hash, is_finished, is_seed, message, name, paused, progress, queue, state, total_size, upload_payload_rate');
+			$torrents = $deluge->getTorrents(null, 'comment, download_payload_rate, eta, hash, is_finished, is_seed, message, name, paused, progress, queue, state, total_size, upload_payload_rate, tracker_status');
 			foreach ($torrents as $key => $value) {
 				$tempStatus = $this->delugeStatus($value->queue, $value->state, $value->progress);
 				if ($tempStatus == 'Seeding' && $this->config['delugeHideSeeding']) {
@@ -136,6 +137,9 @@ trait DelugeHomepageItem
 				} elseif ($tempStatus == 'Finished' && $this->config['delugeHideCompleted']) {
 					//do nothing
 				} else {
+					if ($this->config['delugeHideStatus']){
+						$value->tracker_status = "";
+					}
 					$api['content']['queueItems'][] = $value;
 				}
 			}

--- a/js/functions.js
+++ b/js/functions.js
@@ -6670,7 +6670,9 @@ function buildDownloaderItem(array, source, type='none'){
                 var actionIcon = (v.Status == "Downloading") ? 'pause' : 'play';
                 queue += `
                 <tr>
-                    <td class="max-texts">`+v.name+`</td>
+                    <td class="max-texts">`+v.name;
+		    if (v.tracker_status != "") queue += `<i class="fa fa-caret-down ml-2" style="cursor:pointer" onclick="$(this).toggleClass('fa-caret-down');$(this).toggleClass('fa-caret-up');$('#status-`+v.hash+`').toggleClass('d-none');" aria-hidden="true"></i><br /><div class="well mb-0 mt-2 p-3 d-none" id="status-`+v.hash+`">`+v.tracker_status+`</div>`;
+		    queue +=`</td>
                     <td class="hidden-xs deluge-`+cleanClass(v.state)+`">`+v.state+`</td>
                     <td class="hidden-xs">`+size+`</td>
                     <td class="hidden-xs"><i class="fa fa-download"></i>&nbsp;`+download+`</td>


### PR DESCRIPTION
Added "Hide Status" setting and related updates to be able to control seeing the current status message from tracker_status object through web api