### PR TITLE
change HTTP protocol to 1.1 for image caching function

### DIFF
--- a/api/functions/organizr-functions.php
+++ b/api/functions/organizr-functions.php
@@ -543,8 +543,15 @@ trait OrganizrFunctions
 		}
 		$cacheFile = $cacheDirectory . $name . '.' . $extension;
 		$cacheTime = 604800;
+		$ctx = stream_context_create(array(
+			'http' => array(
+				'timeout' =>5 ,
+				'protocol_version' => 1.1,
+				'header' => 'Connection: close'
+			)
+			));
 		if ((file_exists($cacheFile) && (time() - $cacheTime) > filemtime($cacheFile)) || !file_exists($cacheFile)) {
-			@copy($url, $cacheFile);
+			@copy($url, $cacheFile, $ctx);
 		}
 	}
 


### PR DESCRIPTION
Changed HTTP protocol form 1.0 -> 1.1 to fix image caching issue for backend services that require HTTP 1.1.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29684743/163028822-33bb4543-8c77-40c3-a5aa-08825f1ddeb0.png">
