### PR TITLE
Added check for response to the testConnectionOverseerr method

### DIFF
--- a/api/homepage/overseerr.php
+++ b/api/homepage/overseerr.php
@@ -69,7 +69,8 @@ trait OverseerrHomepageItem
 		try {
 			$options = $this->requestOptions($url, null, $this->config['overseerrDisableCertCheck'], $this->config['overseerrUseCustomCertificate']);
 			$test = Requests::get($url . "/api/v1/settings/main", $headers, $options);
-			if ($test->success) {
+			$testData = json_decode($test->body, true);
+			if ($test->success && isset($testData["apiKey"]) && $testData["apiKey"] == $this->config['overseerrToken']) {
 				$this->setAPIResponse('success', 'API Connection succeeded', 200);
 				return true;
 			} else {


### PR DESCRIPTION
The current implementation only checks for a response of 200 which is also given if the request is redirected elsewhere, e.g. auth provider like authelia and does not check the response of the API call.
The current endpoint for testing also returns the apiKey in the response if the request was authorized.
We can check this against the apiKey in the settings to make the test unambiguous.
https://api-docs.overseerr.dev/#/settings/get_settings_main

`https://overseer/api/v1/settings/main`
```
{
    "apiKey": "<concealed-token>",
    "applicationTitle": "Overseerr",
    ...
}
```