### PR TITLE
Get rid of requester name logic

### DIFF
--- a/api/homepage/overseerr.php
+++ b/api/homepage/overseerr.php
@@ -165,7 +165,7 @@ trait OverseerrHomepageItem
 				$requestAll = [];
 				$requestsData = json_decode($request->body, true);
 				foreach ($requestsData['results'] as $key => $value) {
-					$requester = ($value['requestedBy']['username'] !== '' && $value['requestedBy']['username'] !== null) ? $value['requestedBy']['username'] : $value['requestedBy']['plexUsername'];
+					$requester = $value['requestedBy']['displayName'];
 					$requesterEmail = $value['requestedBy']['email'];
 					$proceed = (($this->config['overseerrLimitUser']) && strtolower($this->user['username']) == strtolower($requester)) || (strtolower($requester) == strtolower($this->config['overseerrFallbackUser'])) || (!$this->config['overseerrLimitUser']) || $this->qualifyRequest(1);
 					if ($proceed) {


### PR DESCRIPTION
I was chatting a bit on the Overseer discord and got a change for the requester name for the overseerr homepage item.
displayName is doing this on Overseerrs side and will include other logic in the future. 
E.g. jellyfin, etc...
Info from TheCatLady@overseerr