### PR TITLE
Changed api key info from overview to app keys tab.

### DIFF
--- a/api/plugins/chat/plugin.php
+++ b/api/plugins/chat/plugin.php
@@ -36,7 +36,7 @@ class Chat extends Organizr
 										<li><i class="fa fa-chevron-right text-danger"></i> <a href="https://dashboard.pusher.com/accounts/sign_up" target="_blank"><span lang="en">Signup for Pusher [FREE]</span></a></li>
 										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Create an App called whatever you like and choose a cluster (Close to you)</span></li>
 										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Frontend (JQuery) - Backend (PHP)</span></li>
-										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Click the overview tab on top left</span></li>
+										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Click the App Keys tab on top left</span></li>
 										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Copy and paste the 4 values into Organizr</span></li>
 										<li><i class="fa fa-chevron-right text-danger"></i> <span lang="en">Save and reload!</span></li>
 									</ul>


### PR DESCRIPTION
Self explanatory, at some point in time the api key tab got moved.

![image](https://github.com/causefx/Organizr/assets/51069105/769254a2-1873-49ea-afee-83a8bd9fc8b5)

I couldn't see a way to change the language within pusher so presumably is English only and thus doesn't require translation.