### PR TITLE
Fix plugins invite user already access

### DIFF
--- a/api/plugins/invites/main.js
+++ b/api/plugins/invites/main.js
@@ -155,8 +155,14 @@ function hasPlexUsername(){
 		organizrAPI2('POST','api/v2/plugins/invites/' + code,post).success(function(data) {
 			var response = data.response;
 			if(response.result === 'success'){
-				$('.invite-step-3-plex-yes').toggleClass('hidden');
-				$('.invite-step-4-plex-accept').toggleClass('hidden');
+				if(response.message == 'Plex User already has access'){
+					$('.invite-step-3-plex-yes').toggleClass('hidden');
+					$('.invite-step-4-plex-accept-already-access').toggleClass('hidden');
+
+				} else {
+					$('.invite-step-3-plex-yes').toggleClass('hidden');
+					$('.invite-step-4-plex-accept').toggleClass('hidden');
+				}
 				if(local('get', 'invite')){
 					local('remove', 'invite');
 				}
@@ -412,6 +418,9 @@ $(document).on('click', '.inviteModal', function() {
 						</div>
 						<div class="form-group invite-step-4-plex-accept hidden">
 							<h4 class="" lang="en">You have been invited.  Please check your email or goto <a href="https://plex.tv" target="_blank">PLEX.TV</a> and login to accept the invite.  Once you have done that, you may head back here and login with your credentials.</h4>
+						</div>
+						<div class="form-group invite-step-4-plex-accept-already-access hidden">
+							<h4 class="" lang="en">You have already access.  Goto <a href="https://plex.tv" target="_blank">PLEX.TV</a> and login.  Once you have done that, you may head back here and login with your credentials.</h4>
 						</div>
 						<!-- Begin Emby Invites -->
 						<div class="form-group invite-step-3-emby-yes hidden">

--- a/api/plugins/invites/main.js
+++ b/api/plugins/invites/main.js
@@ -420,7 +420,7 @@ $(document).on('click', '.inviteModal', function() {
 							<h4 class="" lang="en">You have been invited.  Please check your email or goto <a href="https://plex.tv" target="_blank">PLEX.TV</a> and login to accept the invite.  Once you have done that, you may head back here and login with your credentials.</h4>
 						</div>
 						<div class="form-group invite-step-4-plex-accept-already-access hidden">
-							<h4 class="" lang="en">You have already access.  Goto <a href="https://plex.tv" target="_blank">PLEX.TV</a> and login.  Once you have done that, you may head back here and login with your credentials.</h4>
+							<h4 class="" lang="en">You already have access.  Goto <a href="https://plex.tv" target="_blank">PLEX.TV</a> and login.  Once you have done that, you may head back here and login with your credentials.</h4>
 						</div>
 						<!-- Begin Emby Invites -->
 						<div class="form-group invite-step-3-emby-yes hidden">

--- a/api/plugins/invites/plugin.php
+++ b/api/plugins/invites/plugin.php
@@ -533,7 +533,7 @@ class Invites extends Organizr
 							switch ($response->status_code) {
 								case 400:
 									$this->setLoggerChannel('Plex')->warning('Plex User already has access');
-									$this->setAPIResponse('error', 'Plex User already has access', 409);
+									$this->setAPIResponse('success', 'Plex User already has access', 200);
 									return false;
 								case 401:
 									$this->setLoggerChannel('Plex')->warning('Incorrect Token');


### PR DESCRIPTION
Currently, if a person already has access to the Plex server, the path is blocked, adding a specific message. 