### PR TITLE
Add in V2 Flag for V2 UptimeKuma Support

### DIFF
--- a/api/functions/UptimeKumaMetrics.php
+++ b/api/functions/UptimeKumaMetrics.php
@@ -3,11 +3,13 @@
 class UptimeKumaMetrics
 {
     protected string $raw;
-    private array $monitors = [];
+    private array $monitors = [];    
+	private bool $kumaVersionV2;
 
-    public function __construct(string $raw)
+    public function __construct(string $raw, bool $kumaVersionV2 = false)
     {
         $this->raw = $raw;
+        $this->kumaVersionV2 = $kumaVersionV2;
     }
 
     public function process(): self
@@ -45,13 +47,23 @@ class UptimeKumaMetrics
 		$up = (substr($status, -1)) == '0' ? false : true;
 		$status = substr($status, 15);
 		$status = substr($status, 0, -4);
-		$status = explode(',', $status);
-		$data = [
-			'name' => $this->getStringBetweenQuotes($status[0]),
-			'url' => $this->getStringBetweenQuotes($status[2]),
-			'type' => $this->getStringBetweenQuotes($status[1]),
-			'status' => $up,
-		];
+		$status = explode(',', $status);	
+		if ($this->kumaVersionV2) {
+			$data = [
+				'name' => $this->getStringBetweenQuotes($status[1]),
+				'url' => $this->getStringBetweenQuotes($status[3]),
+				'type' => $this->getStringBetweenQuotes($status[2]),
+				'status' => $up,
+			];
+		}
+		else {
+			$data = [
+				'name' => $this->getStringBetweenQuotes($status[0]),
+				'url' => $this->getStringBetweenQuotes($status[2]),
+				'type' => $this->getStringBetweenQuotes($status[1]),
+				'status' => $up,
+			];
+		}
 
 		return $data;
     }

--- a/api/homepage/uptime_kuma.php
+++ b/api/homepage/uptime_kuma.php
@@ -36,6 +36,7 @@ trait UptimeKumaHomepageItem
 					$this->settingsOption('toggle-title', 'homepageUptimeKumaHeaderToggle'),
 					$this->settingsOption('switch', 'homepageUptimeKumaCompact', ['label' => 'Compact view', 'help' => 'Toggles the compact view of this homepage module']),
 					$this->settingsOption('switch', 'homepageUptimeKumaShowLatency', ['label' => 'Show monitor latency']),
+					$this->settingsOption('switch', 'homepageUptimeKumaVersionV2', ['label' => 'Using V2 of Uptime Kuma']),
 				],
 			]
 		];
@@ -89,7 +90,8 @@ trait UptimeKumaHomepageItem
 				$this->getKumaClient($url, $this->config['uptimeKumaToken'])
 					->get('/metrics')
 					->getBody()
-					->getContents()
+					->getContents(),
+				(bool) $this->config['homepageUptimeKumaVersionV2']
 			))->process();
 
 			$api = [
@@ -99,6 +101,7 @@ trait UptimeKumaHomepageItem
 					'titleToggle' => $this->config['homepageUptimeKumaHeaderToggle'],
 					'compact' => $this->config['homepageUptimeKumaCompact'],
 					'showLatency' => $this->config['homepageUptimeKumaShowLatency'],
+					'kumaVersionV2' => $this->config['homepageUptimeKumaVersionV2'],
 				]
 			];
 		} catch (GuzzleException $e) {


### PR DESCRIPTION
This pull request adds in a V2 flag, allowing users to continue to use V1 api responses, or V2.

Without this flag, your homepage items are returned as:
1, 2, 3, 4, 5, etc.

This Pull Request updates it to select the correct elements that V2 provides, and makes the homepage items return actual names as expected.

Issue #2037 