### PR TITLE
Update qBittorrent 5.2+ session cookie handling

### DIFF
--- a/api/homepage/qbittorrent.php
+++ b/api/homepage/qbittorrent.php
@@ -70,9 +70,27 @@ trait QBitTorrentHomepageItem
 			$cookie = $reflection->getProperty("cookies");
 			$cookie->setAccessible(true);
 			$cookie = $cookie->getValue($response->cookies);
-			if ($cookie) {
+			if ($cookie) {				
+				$sessionCookieName = null;
+				foreach ($cookie as $cookieName => $cookieData) {
+					if ($cookieName === 'SID' || strpos($cookieName, 'QBT_SID_') === 0) {
+						$sessionCookieName = $cookieName;
+						break;
+					}
+				}
+				if ($sessionCookieName === null) {
+					$this->setLoggerChannel('qBittorrent')->warning(
+						'Could not find qBittorrent session cookie'
+					);
+					$this->setAPIResponse(
+						'error',
+						'qBittorrent Connection Error - Could not find session cookie',
+						409
+					);			
+					return false;
+				}
 				$headers = array(
-					'Cookie' => 'SID=' . $cookie['SID']->value
+					'Cookie' => $sessionCookieName . '=' . $cookie[$sessionCookieName]->value
 				);
 				$reverse = $this->config['qBittorrentReverseSorting'] ? 'true' : 'false';
 				$url = $digest['scheme'] . '://' . $digest['host'] . $digest['port'] . $digest['path'] . $apiVersionQuery . $this->config['qBittorrentSortOrder'] . '&reverse=' . $reverse;
@@ -157,8 +175,26 @@ trait QBitTorrentHomepageItem
 			$cookie->setAccessible(true);
 			$cookie = $cookie->getValue($response->cookies);
 			if ($cookie) {
+				$sessionCookieName = null;
+				foreach ($cookie as $cookieName => $cookieData) {
+					if ($cookieName === 'SID' || strpos($cookieName, 'QBT_SID_') === 0) {
+						$sessionCookieName = $cookieName;
+						break;
+					}
+				}
+				if ($sessionCookieName === null) {
+					$this->setLoggerChannel('qBittorrent')->warning(
+						'Could not find qBittorrent session cookie'
+					);
+					$this->setAPIResponse(
+						'error',
+						'qBittorrent Connection Error - Could not find session cookie',
+						409
+					);			
+					return false;
+				}
 				$headers = array(
-					'Cookie' => 'SID=' . $cookie['SID']->value
+					'Cookie' => $sessionCookieName . '=' . $cookie[$sessionCookieName]->value
 				);
 				$reverse = $this->config['qBittorrentReverseSorting'] ? 'true' : 'false';
 				$url = $digest['scheme'] . '://' . $digest['host'] . $digest['port'] . $digest['path'] . $apiVersionQuery . $this->config['qBittorrentSortOrder'] . '&reverse=' . $reverse;


### PR DESCRIPTION
## Summary

Updates the qBittorrent homepage connection code to support the session-cookie naming introduced in qBittorrent 5.2+.

## Problem

The connection code assumes the session cookie is always named `SID`. qBittorrent 5.2+ returns a port-specific cookie such as `QBT_SID_8080`, causing an undefined cookie lookup and HTTP 500 error, as references #2060 

## Change

The returned cookies are searched for either:

- `SID`
- A cookie beginning with `QBT_SID_`

The exact returned cookie name and value are then used in the API request.

## Testing

Tested successfully with:

- qBittorrent 5.2.3
- LinuxServer.io Docker image
- Organizr Docker installation