### PR TITLE
Fix Plex OAuth "Security Alert" on sign-in for IPv6/dual-stack users

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -14678,7 +14678,7 @@ getPlexOAuthPin = function () {
   var x_plex_headers = getPlexHeaders();
   var deferred = $.Deferred();
   $.ajax({
-    url: "https://plex.tv/api/v2/pins?strong=true",
+    url: "https://clients.plex.tv/api/v2/pins?strong=true",
     type: "POST",
     headers: x_plex_headers,
     success: function (data) {
@@ -14733,7 +14733,7 @@ function PlexOAuth(
       (function poll() {
         maxPollCount--;
         $.ajax({
-          url: "https://plex.tv/api/v2/pins/" + pin,
+          url: "https://clients.plex.tv/api/v2/pins/" + pin,
           type: "GET",
           headers: x_plex_headers,
           success: function (data) {


### PR DESCRIPTION
## Problem

Many users see Plex's red **"Security Alert — Another device is attempting to sign in using your Plex account…"** screen (with an IP address highlighted) every time they sign in to Organizr via Plex OAuth — typically on mobile connections and on any IPv6-enabled (dual-stack) network. Signing in from an IPv4-only network never shows it, which makes this very hard for admins to reproduce.

## Root cause

When the approval popup opens, `app.plex.tv`'s auth form re-verifies the PIN with `GET https://clients.plex.tv/api/v2/pins/info?code=…` and chooses the screen from the response (from the auth-form bundle):

```
trusted ? normal : ipMatches ? (isSafeOrigin ? normal : "not hosted by Plex" notice) : SECURITY ALERT
```

`ipMatches` compares the IP that **created** the PIN against the IP of the browser **viewing** the approval screen, and the alert prints the creation IP + geolocation (the response's `source` becomes e.g. `"1.2.3.4 (City, Region, Country)"`).

Organizr creates and polls the PIN on `plex.tv`, which has **no AAAA records (IPv4-only)**, while `clients.plex.tv`/`app.plex.tv` are dual-stack. A visitor with working IPv6 therefore unavoidably creates the PIN over IPv4 but is verified over IPv6 — a guaranteed mismatch, so the Security Alert appears on every sign-in, showing the visitor their own IPv4 address. (Mobile CGNAT connections can hit the same mismatch via per-flow IPv4 egress even without IPv6.)

Verified directly against the API: creating a PIN from one IP and calling `pins/info` from a different IP returns `"ipMatches": false`; calling it from the creating IP returns `true`.

## Fix

Create and poll the PIN on `clients.plex.tv` — the same dual-stack host the approval screen verifies from — so both requests ride the same address family and IP. It is the same PIN store (a PIN created on either host is readable on the other, verified), and the CORS surface is identical (`Access-Control-Allow-Origin: *`; the preflight allows the `X-Plex-*` headers Organizr sends — verified). No behavior change for IPv4-only visitors.

Running in production on our 2.1.5000 instance since 2026-08-25: previously-affected sign-ins now get the normal consent screen instead of the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
